### PR TITLE
Various dockerfile golf which makes a smaller image

### DIFF
--- a/jupyter/lab/beta/Dockerfile
+++ b/jupyter/lab/beta/Dockerfile
@@ -6,24 +6,30 @@ USER root
 
 # Install the icommands, curl, and wget
 RUN apt-get update \
-    && apt-get install -y lsb wget apt-transport-https python2.7 python-requests curl
+    && apt-get install -y lsb wget apt-transport-https python2.7 python-requests curl gnupg \
+    && apt-get clean \
+    && rm -rf /usr/lib/apt/lists/* \
+    && fix-permissions $CONDA_DIR
 
 RUN wget -qO - https://packages.irods.org/irods-signing-key.asc | apt-key add - \
     && echo "deb [arch=amd64] https://packages.irods.org/apt/ xenial main" > /etc/apt/sources.list.d/renci-irods.list \
     && apt-get update \
-    && apt-get install -y irods-icommands
+    && apt-get install -y irods-icommands \
+    && apt-get clean \
+    && rm -rf /usr/lib/apt/lists/* \
+    && fix-permissions $CONDA_DIR
 
 
-RUN chown -R jovyan /opt/conda/
+# RUN chown -R jovyan /opt/conda/
 
 USER jovyan
 
-RUN conda update -n base conda
-RUN conda install jupyterlab=0.33
-RUN jupyter lab --version
-RUN jupyter labextension install @jupyterlab/hub-extension
-RUN	jupyter labextension install @jupyter-widgets/jupyterlab-manager@0.36
-RUN	jupyter labextension install jupyterlab_bokeh
+RUN conda update -n base conda \
+ && conda install jupyterlab=0.33 \
+ && conda clean -tipsy \
+ && fix-permissions $CONDA_DIR
+RUN jupyter lab --version \
+ && jupyter labextension install @jupyterlab/hub-extension @jupyter-widgets/jupyterlab-manager@0.36 jupyterlab_bokeh
 
 # Install the irods plugin for jupyter lab
 #RUN pip install jupyterlab_irods


### PR DESCRIPTION
When built using current latest of `jupyter/datascience-notebook` (6.1GB), this ends up 6.93GB. Built off of the one the current image is (`jupyter/datascience-notebook:1085ca054a5f`, which is 5.69GB), it produces an image which is 6.52GB. The current image is 10.7GB.

Unfortunately I'm not entirely sure how to test if things still work. The biggest gain is in removing a `chown -R jovyan /opt/conda/` which I was guessing was there to make the `conda update`/`conda install` etc. commands to work, but they seem to still work since I added in some calls to `fix-permissions` (which is added to the image/maintained by the jupyter folks). Docker being the annoying creature it is, that layer was almost 4GB by itself, since AFAICT docker just copies... all the files, in full, when you do a chown? Anyway. When built off latest, I think we're also actually *downgrading* jupyter lab, which might not be desired, but anyway.