### PR TITLE
Update Dockerfile for JupyterLab beta w/ latest compatible extensions

### DIFF
--- a/jupyter/lab/beta/Dockerfile
+++ b/jupyter/lab/beta/Dockerfile
@@ -6,29 +6,38 @@ USER root
 
 # Install the icommands, curl, and wget
 RUN apt-get update \
-    && apt-get install -y lsb wget apt-transport-https python2.7 python-requests curl
+    && apt-get install -y lsb wget gnupg apt-transport-https python3.6 python-requests curl \
+    && apt-get clean \
+    && rm -rf /usr/lib/apt/lists/* \
+    && fix-permissions $CONDA_DIR
 
 RUN wget -qO - https://packages.irods.org/irods-signing-key.asc | apt-key add - \
     && echo "deb [arch=amd64] https://packages.irods.org/apt/ xenial main" > /etc/apt/sources.list.d/renci-irods.list \
     && apt-get update \
-    && apt-get install -y irods-icommands
+    && apt-get install -y irods-icommands \
+    && apt-get clean \
+    && rm -rf /usr/lib/apt/lists/* \
+    && fix-permissions $CONDA_DIR
 
-
-RUN chown -R jovyan /opt/conda/
 
 USER jovyan
 
-RUN conda update -n base conda
-RUN conda install jupyterlab=0.33
-RUN jupyter lab --version
-RUN jupyter labextension install @jupyterlab/hub-extension
-RUN	jupyter labextension install @jupyter-widgets/jupyterlab-manager@0.36
-RUN	jupyter labextension install jupyterlab_bokeh
+# install foundational jupyter lab
+RUN conda update -n base conda \
+    && conda install jupyterlab=0.35.4 \
+    && conda clean -tipsy \
+    && fix-permissions $CONDA_DIR
+
+# install jupyter hub and extra doodads
+RUN jupyter lab --version \
+    && jupyter labextension install @jupyterlab/hub-extension@0.12.0 \
+                                    @jupyter-widgets/jupyterlab-manager@0.38.1 \
+                                    jupyterlab_bokeh@0.6.3
 
 # Install the irods plugin for jupyter lab
-#RUN pip install jupyterlab_irods
-#RUN jupyter serverextension enable --py jupyterlab_irods
-#RUN jupyter labextension install @towicode/jupyterlab_irods
+RUN pip install jupyterlab_irods==0.9.0 \
+    && jupyter serverextension enable --py jupyterlab_irods \
+    && jupyter labextension install ijab@2.0.0
 
 ENTRYPOINT ["jupyter"]
 CMD ["lab", "--no-browser"]


### PR DESCRIPTION
Updated extensions for Hub, Manager, Bokeh, jupyterlab_irods and IJab. These have been tested to work together.

This update includes all the changes in (long pending) PR #4 and can replace that PR.
